### PR TITLE
Issue #179 - Initial Jagex Launcher Support

### DIFF
--- a/account_names.txt
+++ b/account_names.txt
@@ -1,0 +1,3 @@
+Add account names here, one per line:
+<Account Name 1>
+<Account Name 2>

--- a/src/model/osrs/jagex_account_bot.py
+++ b/src/model/osrs/jagex_account_bot.py
@@ -1,0 +1,59 @@
+"""
+The OSRSJagexAccountBot class for launching bots via Runelite for a Jagex Account
+"""
+from abc import ABCMeta
+import wmi
+import pywinctl
+import pyautogui
+
+from model.runelite_bot import RuneLiteBot, RuneLiteWindow
+
+ACCOUNTS_FILE = "./account_names.txt"
+
+def read_accounts_file_lines(file_path=ACCOUNTS_FILE):
+    try:
+        with open(file_path, 'r') as file:
+            lines = file.readlines()
+        return lines
+    except FileNotFoundError:
+        print(f"Account Names '{file_path}' not found. Please ensure you execute OSBC.py from the root directory.")
+        return []
+
+class OSRSJagexAccountBot(RuneLiteBot, metaclass=ABCMeta):
+    win: RuneLiteWindow = None
+
+    def __init__(self, bot_title, description, account_name=None, debug=False) -> None:
+        """
+        account_name: Allows an override of the accounts file by specifying the exact account name
+        debug: If True, prints additional information on processes if RuneLite was not found
+        """
+        try:
+            super().__init__("OSRS", bot_title, description, window=RuneLiteWindow("RuneLite"))
+        except:
+            print("No default RuneLite process, looking for others.") if debug else ""
+
+        if not account_name:
+            print("Looking for a Runelite instance running for any listed account") if debug else ""
+        else:
+            super().__init__("OSRS", bot_title, description, window=window)
+        
+        accounts = read_accounts_file_lines()
+        if not accounts:
+            raise Exception("No accounts found. Cannot instantiate bot.")
+        
+        for account_name in accounts:
+            window_name = f"RuneLite - {account_name}"
+            print(f"Looking for '{window_name}'") if debug else ""
+            if window := pywinctl.getWindowsWithTitle(window_name):
+                super().__init__("OSRS", bot_title, description, window=RuneLiteWindow(window_name))
+        if not window:
+            if not debug:
+                raise Exception("No runeline version found. Please ensure you're logged in.")
+            else:
+                print("Printing RuneLite processes... This may take some time")
+                print("Please ensure the account you'd like to run is listed in your accounts")
+                for window in pyautogui.getAllWindows():
+                    if window.title and "runelite" in window.title.lower():  
+                        print(window.title)
+
+

--- a/src/model/osrs/jagex_account_bot_template.py
+++ b/src/model/osrs/jagex_account_bot_template.py
@@ -1,0 +1,71 @@
+import time
+
+import utilities.api.item_ids as ids
+import utilities.color as clr
+import utilities.random_util as rd
+from model.osrs.jagex_account_bot import OSRSJagexAccountBot
+from utilities.api.morg_http_client import MorgHTTPSocket
+from utilities.api.status_socket import StatusSocket
+
+
+class OSRSTemplate(OSRSJagexAccountBot):
+    def __init__(self):
+        bot_title = "<Script name here>"
+        description = "<Script description here>"
+        # Ensure to fill out the account_names.txt file or set an account name here
+        super().__init__(bot_title=bot_title, description=description, account_name=None, debug=False)
+
+        # Set option variables below (initial value is only used during headless testing)
+        self.running_time = 1
+
+    def create_options(self):
+        """
+        Use the OptionsBuilder to define the options for the bot. For each function call below,
+        we define the type of option we want to create, its key, a label for the option that the user will
+        see, and the possible values the user can select. The key is used in the save_options function to
+        unpack the dictionary of options after the user has selected them.
+        """
+        self.options_builder.add_slider_option("running_time", "How long to run (minutes)?", 1, 500)
+        self.options_builder.add_text_edit_option("text_edit_example", "Text Edit Example", "Placeholder text here")
+        self.options_builder.add_checkbox_option("multi_select_example", "Multi-select Example", ["A", "B", "C"])
+        self.options_builder.add_dropdown_option("menu_example", "Menu Example", ["A", "B", "C"])
+
+    def save_options(self, options: dict):
+        """
+        For each option in the dictionary, if it is an expected option, save the value as a property of the bot.
+        If any unexpected options are found, log a warning. If an option is missing, set the options_set flag to
+        False.
+        """
+        for option in options:
+            if option == "running_time":
+                self.running_time = options[option]
+            elif option == "text_edit_example":
+                self.log_msg(f"Text edit example: {options[option]}")
+            elif option == "multi_select_example":
+                self.log_msg(f"Multi-select example: {options[option]}")
+            elif option == "menu_example":
+                self.log_msg(f"Menu example: {options[option]}")
+            else:
+                self.log_msg(f"Unknown option: {option}")
+                print("Developer: ensure that the option keys are correct, and that options are being unpacked correctly.")
+                self.options_set = False
+                return
+        self.log_msg(f"Running time: {self.running_time} minutes.")
+        self.log_msg("Options set successfully.")
+        self.options_set = True
+
+    def main_loop(self):
+        """
+        When implementing this function, you have the following responsibilities:
+        1. If you need to halt the bot from within this function, call `self.stop()`. You'll want to do this
+           when the bot has made a mistake, gets stuck, or a condition is met that requires the bot to stop.
+        2. Frequently call self.update_progress() and self.log_msg() to send information to the UI.
+        3. At the end of the main loop, make sure to call `self.stop()`.
+
+        Additional notes:
+        - Make use of Bot/RuneLiteBot member functions. There are many functions to simplify various actions.
+          Visit the Wiki for more.
+        - Using the available APIs is highly recommended. Some of all of the API tools may be unavailable for
+          select private servers. For usage, uncomment the `api_m` and/or `api_s` lines below, and use the `.`
+          operator to access their functions.
+        """


### PR DESCRIPTION
I took a shot at addressing https://github.com/kelltom/OS-Bot-COLOR/issues/179

The core issues that I found were:
1. The lack of ability to launch RuneLite
 > When attempting to login via a RuneLite instance not launched by the Jagex Launcher, you receive an error.
2. Window name
> The window name typically was `RuneLite` when launched by OSBC, but the Jagex Launcher appends an account name (`RuneLite - <Account Name>`)

This PR creates a new bot model for OSRS, inheriting from RuneLiteBot, which will search for the Jagex Client launched RuneLite instance. It does this utilizing an account names list populated by the user.

There are also options added to the class for specifying account name directly or enabling a debug mode for additional logging/info

Note: _This doesn't allow for automated launching of RuneLite via the Jagex Launcher and requires manual launching/login._
Note: _This also does not create a RuneLite profile (for things like the socket plugins & configuration), so either using another, already created profile or manually creating one is required._  